### PR TITLE
Eliminate the use of deprecated utcnow()

### DIFF
--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -100,7 +100,7 @@ def get_ssl_certificates(env):
 
 	# Sort the certificates to prefer good ones.
 	import datetime
-	now = datetime.datetime.utcnow()
+	now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 	ret = { }
 	for domain, cert_list in domains.items():
 		#for c in cert_list: print(domain, c["cert"].not_valid_before, c["cert"].not_valid_after, "("+str(now)+")", c["cert"].issuer, c["cert"].subject, c._filename if hasattr(c,"_filename") else "")
@@ -579,7 +579,7 @@ def check_certificate(domain, ssl_certificate, ssl_private_key, warn_if_expiring
 	# Check that the certificate hasn't expired. The datetimes returned by the
 	# certificate are 'naive' and in UTC. We need to get the current time in UTC.
 	import datetime
-	now = datetime.datetime.utcnow()
+	now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 	if not(cert.not_valid_before <= now <= cert.not_valid_after):
 		return (f"The certificate has expired or is not yet valid. It is valid from {cert.not_valid_before} to {cert.not_valid_after}.", None)
 


### PR DESCRIPTION
Starting In Python3.12, a deprecation warning is printed when calling datetime.datetime.utcnow():

```
management/ssl_certificates.py:103: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)
```

Both MIAB-LDAP and MIAB only run on Ubuntu 22 (Jammy), which has Python 3.10, and does not receive this warning message. However, the code is shared with the cloud-in-a-box project, which runs on Ubuntu 24 (Noble) and does gets this message so am fixing it here, at the "source".
